### PR TITLE
earlier hotkey initialization

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGTClient.java
+++ b/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGTClient.java
@@ -6,7 +6,6 @@ import com.redlimerl.speedrunigt.impl.OptionButtonsImpl;
 import com.redlimerl.speedrunigt.option.SpeedRunOption;
 import com.redlimerl.speedrunigt.therun.TheRunKeyHelper;
 import com.redlimerl.speedrunigt.timer.TimerDrawer;
-import com.redlimerl.speedrunigt.utils.KeyBindingRegistry;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
@@ -43,18 +42,6 @@ public class SpeedRunIGTClient implements ClientModInitializer {
 
         // End initializing
         isInitialized = true;
-
-        // Key Bindings initialize
-        timerResetKeyBinding = KeyBindingRegistry.registerKeyBinding(new KeyBinding(
-                "speedrunigt.controls.start_timer",
-                22,
-                "speedrunigt.title.options"
-        ));
-        timerStopKeyBinding = KeyBindingRegistry.registerKeyBinding(new KeyBinding(
-                "speedrunigt.controls.stop_timer",
-                23,
-                "speedrunigt.title.options"
-        ));
 
         TheRunKeyHelper.load();
 

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/keybinding/GameOptionsMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/keybinding/GameOptionsMixin.java
@@ -1,5 +1,6 @@
 package com.redlimerl.speedrunigt.mixins.keybinding;
 
+import com.redlimerl.speedrunigt.SpeedRunIGTClient;
 import com.redlimerl.speedrunigt.utils.KeyBindingRegistry;
 import net.minecraft.client.options.GameOptions;
 import net.minecraft.client.options.KeyBinding;
@@ -16,6 +17,17 @@ public class GameOptionsMixin {
 
     @Inject(at = @At("HEAD"), method = "load()V")
     public void loadHook(CallbackInfo info) {
+        // Key Bindings initialize
+        SpeedRunIGTClient.timerResetKeyBinding = KeyBindingRegistry.registerKeyBinding(new KeyBinding(
+                "speedrunigt.controls.start_timer",
+                22,
+                "speedrunigt.title.options"
+        ));
+        SpeedRunIGTClient.timerStopKeyBinding = KeyBindingRegistry.registerKeyBinding(new KeyBinding(
+                "speedrunigt.controls.stop_timer",
+                23,
+                "speedrunigt.title.options"
+        ));
         keysAll = KeyBindingRegistry.process(keysAll);
     }
 }

--- a/src/main/java/com/redlimerl/speedrunigt/utils/KeyBindingRegistry.java
+++ b/src/main/java/com/redlimerl/speedrunigt/utils/KeyBindingRegistry.java
@@ -19,7 +19,6 @@
 package com.redlimerl.speedrunigt.utils;
 
 import com.google.common.collect.Lists;
-import com.redlimerl.speedrunigt.SpeedRunIGTClient;
 import net.minecraft.client.options.KeyBinding;
 
 import java.util.List;
@@ -37,18 +36,6 @@ public final class KeyBindingRegistry {
      * we can make sure that there are no duplicates this way.
      */
     public static KeyBinding[] process(KeyBinding[] keysAll) {
-        // Key Bindings initialize
-        SpeedRunIGTClient.timerResetKeyBinding = registerKeyBinding(new KeyBinding(
-                "speedrunigt.controls.start_timer",
-                22,
-                "speedrunigt.title.options"
-        ));
-        SpeedRunIGTClient.timerStopKeyBinding = registerKeyBinding(new KeyBinding(
-                "speedrunigt.controls.stop_timer",
-                23,
-                "speedrunigt.title.options"
-        ));
-
         List<KeyBinding> newKeysAll = Lists.newArrayList(keysAll);
         newKeysAll.removeAll(moddedKeyBindings);
         newKeysAll.addAll(moddedKeyBindings);


### PR DESCRIPTION
## Merge base version
- MC Version: 1.7.10
- SpeedRunIGT Version: 13.6

## Changes
make hotkeys initialized immediately before they are registered, as `GameOptions$load` is called before the Client Mod Initializer is run in this version which caused there to be zero modifiedHotkeys at the time the hook is loaded. Additionally, this removes the re-initialization of hotkeys inside the api hook, because that would cause that key to stay bound to it's default keycode, not allowing any other key to be bound to it, despite what the hotkey screen seemed to suggest visually.