### PR TITLE
use ~/.speedrunigt on linux

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGT.java
+++ b/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGT.java
@@ -12,6 +12,7 @@ import com.redlimerl.speedrunigt.timer.category.CustomCategoryManager;
 import com.redlimerl.speedrunigt.timer.category.RunCategory;
 import com.redlimerl.speedrunigt.timer.category.condition.CategoryCondition;
 import com.redlimerl.speedrunigt.timer.packet.TimerPackets;
+import com.redlimerl.speedrunigt.utils.FilesHelper;
 import com.redlimerl.speedrunigt.utils.FontIdentifier;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
@@ -54,7 +55,7 @@ public class SpeedRunIGT implements ModInitializer {
     public static Path getMainPath() {
         return FabricLoader.getInstance().getGameDir().resolve(MOD_ID);
     }
-    public static Path getRecordsPath() { return getGlobalPath().resolve("records");}
+    public static Path getRecordsPath() { return getGlobalPath().resolve("records"); }
     public static Path getGlobalPath() {
         String home = System.getProperty("user.home").replace("\\", "/");
         Path path = new File(home, SpeedRunIGT.MOD_ID).toPath();
@@ -63,11 +64,7 @@ public class SpeedRunIGT implements ModInitializer {
             // used to use ~/speedrunigt instead of ~/.speedrunigt on linux
             // if only the old directory exists we need to copy it over to the new one
             if (Files.exists(path) && !Files.exists(linuxPath)) {
-                try {
-                    Files.copy(path, linuxPath);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+                FilesHelper.recursiveCopy(path, linuxPath);
             }
             return linuxPath;
         } else {

--- a/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGT.java
+++ b/src/main/java/com/redlimerl/speedrunigt/SpeedRunIGT.java
@@ -19,12 +19,14 @@ import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
@@ -52,8 +54,26 @@ public class SpeedRunIGT implements ModInitializer {
     public static Path getMainPath() {
         return FabricLoader.getInstance().getGameDir().resolve(MOD_ID);
     }
-    public static Path getGlobalPath() { return new File(System.getProperty("user.home").replace("\\", "/"), SpeedRunIGT.MOD_ID).toPath(); }
-    public static Path getRecordsPath() { return getGlobalPath().resolve("records"); }
+    public static Path getRecordsPath() { return getGlobalPath().resolve("records");}
+    public static Path getGlobalPath() {
+        String home = System.getProperty("user.home").replace("\\", "/");
+        Path path = new File(home, SpeedRunIGT.MOD_ID).toPath();
+        Path linuxPath = new File(home, "." + SpeedRunIGT.MOD_ID).toPath();
+        if (Util.getOperatingSystem() == Util.OperatingSystem.LINUX) {
+            // used to use ~/speedrunigt instead of ~/.speedrunigt on linux
+            // if only the old directory exists we need to copy it over to the new one
+            if (Files.exists(path) && !Files.exists(linuxPath)) {
+                try {
+                    Files.copy(path, linuxPath);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return linuxPath;
+        } else {
+            return path;
+        }
+    }
 
     public static final Set<ModContainer> API_PROVIDERS = Sets.newHashSet();
 

--- a/src/main/java/com/redlimerl/speedrunigt/utils/FilesHelper.java
+++ b/src/main/java/com/redlimerl/speedrunigt/utils/FilesHelper.java
@@ -1,0 +1,31 @@
+package com.redlimerl.speedrunigt.utils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class FilesHelper {
+    public static void recursiveCopy(Path oldPath, Path newPath) {
+        try {
+            Files.createDirectories(oldPath);
+            Files.walkFileTree(oldPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.copy(file, newPath.resolve(oldPath.relativize(file)));
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
+                    Files.createDirectories(newPath.resolve(oldPath.relativize(dir)));
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
## Merge base version
- MC Version: [1.16.1]
- SpeedRunIGT Version: [14.0]

## Changes
makes the global config folder location on linux default to ~/.speedrunigt, copying the old ~/speedrunigt folder if it exists and the new one doesn't