### PR TITLE
Fix global file fighting

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/events/EventRepository.java
+++ b/src/main/java/com/redlimerl/speedrunigt/events/EventRepository.java
@@ -62,23 +62,42 @@ public class EventRepository {
     public void add(Event event) {
         GameInstance.SAVE_MANAGER_THREAD.submit(() -> {
             try {
-                Files.write(
-                        this.eventsPath,
-                        (this.serializeEvent(event) + "\n").getBytes(Charset.defaultCharset()),
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.APPEND
-                );
-                Files.write(
-                        this.globalEventsPath,
-                        (this.world.getWorldData() + "\n").getBytes(Charset.defaultCharset()),
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.WRITE,
-                        StandardOpenOption.TRUNCATE_EXISTING
-                );
+                writeEventToLog(event);
+                writeWorldDataToGlobalFile();
                 LOGGER.info("Successfully appended to events files.");
             } catch (IOException e) {
                 LOGGER.error("Error while writing to events files", e);
             }
         });
+    }
+
+    public void addOnlyToLog(Event event) {
+        GameInstance.SAVE_MANAGER_THREAD.submit(() -> {
+            try {
+                writeEventToLog(event);
+                LOGGER.info("Successfully appended to events file.");
+            } catch (IOException e) {
+                LOGGER.error("Error while writing to events files", e);
+            }
+        });
+    }
+
+    private void writeEventToLog(Event event) throws IOException {
+        Files.write(
+                this.eventsPath,
+                (this.serializeEvent(event) + "\n").getBytes(Charset.defaultCharset()),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND
+        );
+    }
+
+    private void writeWorldDataToGlobalFile() throws IOException {
+        Files.write(
+                this.globalEventsPath,
+                (this.world.getWorldData() + "\n").getBytes(Charset.defaultCharset()),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING
+        );
     }
 }

--- a/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
+++ b/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
@@ -88,7 +88,7 @@ public class GameInstance {
                         LOGGER.error("Couldn't add buffered event to events array.");
                         return;
                     }
-                    this.world.getEventRepository().add(bufferedEvent);
+                    this.sendEventToRepository(bufferedEvent);
                     this.bufferedEvents.remove(bufferedEvent);
                     removed++;
                 }
@@ -101,8 +101,8 @@ public class GameInstance {
         if (this.world != null && this.events != null) {
             if (this.canTriggerEvent(event)) {
                 this.addBufferedEvents();
-                this.world.getEventRepository().add(event);
                 this.events.add(event);
+                this.sendEventToRepository(event);
             }
         } else {
             this.bufferedEvents.add(event);
@@ -141,5 +141,17 @@ public class GameInstance {
 
     public boolean hasWorldLoaded() {
         return this.world != null;
+    }
+
+    private boolean shouldUpdateGlobal(Event event) {
+        return this.events.size() > 1 || !event.type.equals("leave_world");
+    }
+
+    private void sendEventToRepository(Event event) {
+        if (this.shouldUpdateGlobal(event)) {
+            this.world.getEventRepository().add(event);
+        } else {
+            this.world.getEventRepository().addOnlyToLog(event);
+        }
     }
 }


### PR DESCRIPTION
## Merge base version
- MC Version: 1.16.1
- SpeedRunIGT Version: 14.0

## Changes
Fixes a side effect of the leave world event where the global file is updated constantly.
It does this by adding a `shouldUpdateGlobal` method which requires > 1 event or an event that isn't of the type `leave_world`.

## More details
When making the global world data file (`%userprofile%/speedrunigt/latest_world.json`), we assumed that it would only update when a player is on a run (like at least in the nether).
This was broken (by me) because the global file updates when leaving worlds due to the `common.leave_world` event. This happens when a world is reset after the preview, so this happens quite often on the wall. It's possible this could cause race conditions for writing to the global file, where instances "fight" for it.
A work-around was made in the PaceMan Tracker, but the behavior still exists in the mod itself.

A simple solution is to not update the global file when there is only leave world events (the solution in this PR).
A more complicated but more fitting system would be a `"meaningful":false` added onto the leave world event, and if there is only one non-meaningful event, don't write global file, but this is a lot more fluff and work, and we can add it later if we reaaaaaally need.
