### PR TITLE
Add more advancements as events

### DIFF
--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -1,9 +1,37 @@
 [
     {
+        "name": "obtain_iron_ingot",
+        "type": "advancement",
+        "data": {
+            "advancement": "story/smelt_iron"
+        }
+    },
+    {
+        "name": "obtain_iron_pickaxe",
+        "type": "advancement",
+        "data": {
+            "advancement": "story/iron_tools"
+        }
+    },
+    {
+        "name": "obtain_lava_bucket",
+        "type": "advancement",
+        "data": {
+            "advancement": "story/lava_bucket"
+        }
+    },
+    {
         "name": "enter_nether",
         "type": "advancement",
         "data": {
             "advancement": "story/enter_the_nether"
+        }
+    },
+    {
+        "name": "distract_piglin",
+        "type": "advancement",
+        "data": {
+            "advancement": "nether/distract_piglin"
         }
     },
     {
@@ -14,10 +42,38 @@
         }
     },
     {
+        "name": "loot_bastion",
+        "type": "advancement",
+        "data": {
+            "advancement": "nether/loot_bastion"
+        }
+    },
+    {
+        "name": "obtain_obsidian",
+        "type": "advancement",
+        "data": {
+            "advancement": "story/form_obsidian"
+        }
+    },
+    {
+        "name": "obtain_crying_obsidian",
+        "type": "advancement",
+        "data": {
+            "advancement": "nether/obtain_crying_obsidian"
+        }
+    },
+    {
         "name": "enter_fortress",
         "type": "advancement",
         "data": {
             "advancement": "nether/find_fortress"
+        }
+    },
+    {
+        "name": "obtain_blaze_rod",
+        "type": "advancement",
+        "data": {
+            "advancement": "nether/obtain_blaze_rod"
         }
     },
     {


### PR DESCRIPTION
## Merge base version
- MC Version: 1.16.1
- SpeedRunIGT Version: 14.0

## Changes
Add more advancements as events. New events:
- `rsg.obtain_iron_ingot`
- `rsg.obtain_iron_pickaxe`
- `rsg.obtain_lava_bucket`
- `rsg.distract_piglin`
- `rsg.loot_bastion`
- `rsg.obtain_obsidian`
- `rsg.obtain_crying_obsidian`
- `rsg.obtain_blaze_rod`