### PR TITLE
Multiplayer Event, Old World Event, and Disable Events System for Dedicated Servers

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
+++ b/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
@@ -49,6 +49,9 @@ public class GameInstance {
     }
 
     public void tryLoadWorld(String worldName) {
+        if (!SpeedRunIGT.IS_CLIENT_SIDE) {
+            return;
+        }
         File worldFile = InGameTimerUtils.getTimerLogDir(worldName, "");
         if (worldFile != null) {
             this.loadWorld(worldFile.toPath());
@@ -74,7 +77,7 @@ public class GameInstance {
     }
 
     public void ensureWorld() {
-        if (!this.hasWorldLoaded()) {
+        if (SpeedRunIGT.IS_CLIENT_SIDE && !this.hasWorldLoaded()) {
             InGameTimer timer = InGameTimer.getInstance();
             LOGGER.info("Attempting event world load at " + timer.getWorldName());
             this.tryLoadWorld(timer.getWorldName());
@@ -132,6 +135,7 @@ public class GameInstance {
     }
 
     public void callEvents(String type, Function<EventFactory, Boolean> condition) {
+        if (!SpeedRunIGT.IS_CLIENT_SIDE) return;
         for (EventFactory factory : EventFactoryLoader.getEventFactories(type)) {
             if (condition == null || condition.apply(factory)) {
                 this.addEvent(factory.create());

--- a/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
+++ b/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
@@ -6,6 +6,7 @@ import com.redlimerl.speedrunigt.events.EventFactory;
 import com.redlimerl.speedrunigt.events.EventFactoryLoader;
 import com.redlimerl.speedrunigt.timer.InGameTimer;
 import com.redlimerl.speedrunigt.timer.InGameTimerUtils;
+import net.minecraft.client.MinecraftClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -13,6 +14,8 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -41,17 +44,32 @@ public class GameInstance {
         }
     }
 
+    private static UUID getLocalPlayerID() {
+        return MinecraftClient.getInstance().getSession().getProfile().getId();
+    }
+
     public void tryLoadWorld(String worldName) {
         File worldFile = InGameTimerUtils.getTimerLogDir(worldName, "");
         if (worldFile != null) {
             this.loadWorld(worldFile.toPath());
             LOGGER.info("Loaded events world.");
-            boolean isRejoin = this.events.stream().anyMatch(event -> event.type.equals("leave_world"));
-            if (isRejoin) {
-                this.callEvents("rejoin_world");
-            }
+            checkJoinEvents();
         } else {
             LOGGER.error("Didn't load events world.");
+        }
+    }
+
+    private void checkJoinEvents() {
+        // Rejoin
+        if (this.events.stream().anyMatch(event -> event.type.equals("leave_world"))) {
+            this.callEvents("rejoin_world");
+        }
+
+        // Multiplayer check
+        if (this.events.stream().anyMatch(event -> event.type.equals("multiplayer"))) return;
+        Set<UUID> previousPlayers = this.world.getPreviousPlayers();
+        if (previousPlayers.size() > 1 || (previousPlayers.size() == 1 && previousPlayers.stream().noneMatch(uuid -> uuid.equals(getLocalPlayerID())))) {
+            this.callEvents("multiplayer");
         }
     }
 

--- a/src/main/java/com/redlimerl/speedrunigt/instance/TimerWorld.java
+++ b/src/main/java/com/redlimerl/speedrunigt/instance/TimerWorld.java
@@ -11,7 +11,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 
 import java.nio.file.Path;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TimerWorld {
@@ -47,5 +47,16 @@ public class TimerWorld {
 
     public EventRepository getEventRepository() {
         return this.eventRepository;
+    }
+
+    /**
+     * Gets the UUIDs of all players that have previously played this world
+     */
+    public Set<UUID> getPreviousPlayers() {
+        try {
+            return Arrays.stream(Objects.requireNonNull(worldFolderPath.resolveSibling("stats").toFile().list())).map(s -> UUID.fromString(s.split("\\.")[0])).collect(Collectors.toSet());
+        } catch (Exception e) {
+            return Collections.emptySet();
+        }
     }
 }

--- a/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
+++ b/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
@@ -800,7 +800,7 @@ public class InGameTimer implements Serializable {
     }
 
     public void openedLanIntegratedServer() {
-        GameInstance.getInstance().callEvents("open_to_lan");
+        GameInstance.getInstance().callEvents("multiplayer");
         this.lanOpenedTime = this.getRealTimeAttack();
     }
 

--- a/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
+++ b/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
@@ -150,6 +150,8 @@ public class InGameTimer implements Serializable {
         GameInstance.getInstance().tryLoadWorld(worldName);
         if (runType.equals(RunType.SET_SEED)) {
             GameInstance.getInstance().callEvents("view_seed");
+        } else if (runType.equals(RunType.OLD_WORLD)) {
+            GameInstance.getInstance().callEvents("old_world");
         }
     }
 

--- a/src/main/resources/events/common.json
+++ b/src/main/resources/events/common.json
@@ -4,6 +4,10 @@
         "type": "view_seed"
     },
     {
+        "name": "old_world",
+        "type": "old_world"
+    },
+    {
         "name": "enable_cheats",
         "type": "enable_cheats"
     },

--- a/src/main/resources/events/common.json
+++ b/src/main/resources/events/common.json
@@ -8,8 +8,8 @@
         "type": "enable_cheats"
     },
     {
-        "name": "open_to_lan",
-        "type": "open_to_lan"
+        "name": "multiplayer",
+        "type": "multiplayer"
     },
     {
         "name": "leave_world",


### PR DESCRIPTION
## Merge base version
- MC Version: 1.16.1
- SpeedRunIGT Version: 14.0

## Changes
- Rename `open_to_lan` type and common event to `multiplayer`
  - This functions the same with the addition of also being called when more than 1 unique player has ever played the world. (Can occur by passing around files)
- Added `old_world` event type and common event, which is called when an OLD_WORLD run type is started
- Disabled events system for dedicated servers