### PR TITLE
fix in-game credits button stopping timer

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreditsScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreditsScreenMixin.java
@@ -7,7 +7,9 @@ import com.redlimerl.speedrunigt.timer.TimerStatus;
 import com.redlimerl.speedrunigt.timer.category.RunCategories;
 import net.minecraft.client.gui.screen.CreditsScreen;
 import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -15,14 +17,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(CreditsScreen.class)
 public class CreditsScreenMixin {
 
+    @Shadow
+    @Final
+    private boolean endCredits;
+
     @Inject(method = "init()V", at = @At("TAIL"))
     private void initMixin(CallbackInfo ci) {
+        if (!this.endCredits) {
+            return;
+        }
+
         @NotNull
         InGameTimer timer = InGameTimer.getInstance();
         if (timer.getStatus() != TimerStatus.NONE) {
             int anyToAATime = SpeedRunOption.getOption(SpeedRunOptions.CHANGE_ANY_TO_AA_OVER);
             if (anyToAATime > 0 && (timer.getCategory() == RunCategories.ANY || timer.getCategory() == RunCategories.ALL_ADVANCEMENTS)) {
-                if (timer.getInGameTime() < 1000L*60*anyToAATime) {
+                if (timer.getInGameTime() < 1000L * 60 * anyToAATime) {
                     timer.setCategory(RunCategories.ANY, true);
                 } else {
                     timer.setCategory(RunCategories.ALL_ADVANCEMENTS, true);


### PR DESCRIPTION
## Merge base version
- MC Version: 1.19.4
- SpeedRunIGT Version: 13.6

## Changes
fix in-game credits button stopping timer

## More details (Optional)
applicable to 1.19.3+ iirc
example video: https://youtu.be/DdNuo1NrEDU