### PR TITLE
rethink events for achievements

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/AchievementNotificationMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/AchievementNotificationMixin.java
@@ -1,6 +1,7 @@
 package com.redlimerl.speedrunigt.mixins;
 
 import com.google.common.collect.Lists;
+import com.redlimerl.speedrunigt.instance.GameInstance;
 import com.redlimerl.speedrunigt.timer.InGameTimer;
 import com.redlimerl.speedrunigt.timer.TimerAdvancementTracker;
 import com.redlimerl.speedrunigt.timer.TimerStatus;
@@ -28,6 +29,9 @@ public abstract class AchievementNotificationMixin {
         InGameTimer timer = InGameTimer.getInstance();
 
         if (timer.getStatus() == TimerStatus.NONE) return;
+
+        // Events system
+        GameInstance.getInstance().callEvents("achievement", factory -> achieved.name.substring("achievement.".length()).equals(factory.getDataValue("achievement")));
 
         // For Timeline
         timer.tryInsertNewAdvancement(achieved.name, null, true);

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -1,79 +1,23 @@
 [
     {
         "name": "obtain_iron_ingot",
-        "type": "advancement",
+        "type": "achievement",
         "data": {
-            "advancement": "story/smelt_iron"
-        }
-    },
-    {
-        "name": "obtain_iron_pickaxe",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/iron_tools"
-        }
-    },
-    {
-        "name": "obtain_lava_bucket",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/lava_bucket"
+            "achievement": "acquireIron"
         }
     },
     {
         "name": "enter_nether",
-        "type": "advancement",
+        "type": "insert_timeline",
         "data": {
-            "advancement": "story/enter_the_nether"
+            "timeline": "enter_nether"
         }
     },
     {
-        "name": "distract_piglin",
-        "type": "advancement",
+        "name": "killed_blaze",
+        "type": "timeline",
         "data": {
-            "advancement": "nether/distract_piglin"
-        }
-    },
-    {
-        "name": "enter_bastion",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/find_bastion"
-        }
-    },
-    {
-        "name": "loot_bastion",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/loot_bastion"
-        }
-    },
-    {
-        "name": "obtain_obsidian",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/form_obsidian"
-        }
-    },
-    {
-        "name": "obtain_crying_obsidian",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/obtain_crying_obsidian"
-        }
-    },
-    {
-        "name": "enter_fortress",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/find_fortress"
-        }
-    },
-    {
-        "name": "obtain_blaze_rod",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/obtain_blaze_rod"
+            "timeline": "killed_blaze"
         }
     },
     {
@@ -91,24 +35,17 @@
         }
     },
     {
-        "name": "enter_stronghold",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/follow_ender_eye"
-        }
-    },
-    {
         "name": "enter_end",
-        "type": "advancement",
+        "type": "insert_timeline",
         "data": {
-            "advancement": "story/enter_the_end"
+            "timeline": "enter_end"
         }
     },
     {
         "name": "kill_dragon",
         "type": "insert_timeline",
         "data": {
-            "entity": "kill_ender_dragon"
+            "timeline": "kill_ender_dragon"
         }
     },
     {


### PR DESCRIPTION
## Merge base version
- MC Version: 1.11.2
- SpeedRunIGT Version: 14.1

## Changes
port rsg advancement events of 1.12+ to a mix of timelines and achievements

this cherrypicks to all legacy fabric versions, hopefully without any merge conflicts. at least it does on 1.7.4.