### PR TITLE
1.4.7 - various fixes

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
+++ b/src/main/java/com/redlimerl/speedrunigt/instance/GameInstance.java
@@ -44,7 +44,7 @@ public class GameInstance {
     }
 
     private static String getLocalPlayerID() {
-        return Minecraft.getMinecraft().session.username;
+        return Minecraft.getMinecraft().session.username.toLowerCase();
     }
 
     public void tryLoadWorld(String worldName) {

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/AchievementNotificationMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/AchievementNotificationMixin.java
@@ -1,6 +1,7 @@
 package com.redlimerl.speedrunigt.mixins;
 
 import com.google.common.collect.Lists;
+import com.redlimerl.speedrunigt.instance.GameInstance;
 import com.redlimerl.speedrunigt.timer.InGameTimer;
 import com.redlimerl.speedrunigt.timer.TimerAdvancementTracker;
 import com.redlimerl.speedrunigt.timer.TimerStatus;
@@ -28,6 +29,9 @@ public abstract class AchievementNotificationMixin {
         InGameTimer timer = InGameTimer.getInstance();
 
         if (timer.getStatus() == TimerStatus.NONE) return;
+
+        // Events system
+        GameInstance.getInstance().callEvents("achievement", factory -> achieved.getStringId().substring("achievement.".length()).equals(factory.getDataValue("achievement")));
 
         // For Timeline
         timer.tryInsertNewAdvancement(achieved.getStringId(), null, true);

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
@@ -4,6 +4,7 @@ import com.redlimerl.speedrunigt.timer.InGameTimerUtils;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,14 +14,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-@Mixin(CreateWorldScreen.class)
+@Mixin(value = CreateWorldScreen.class, priority = 1050)
 public class CreateWorldScreenMixin {
 
     @Shadow private TextFieldWidget seedField;
 
     @Inject(method = "buttonClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;method_2935(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE))
     public void onGenerate(CallbackInfo ci) {
-        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0") || isAtumSetSeed();
+        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0");
+    }
+
+    @Dynamic
+    // method injected by atum
+    @Inject(method = "createLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;startIntegratedServer(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE), require = 0)
+    public void onGenerateAtum(CallbackInfo ci) {
+        InGameTimerUtils.IS_SET_SEED = isAtumSetSeed();
     }
 
     private boolean isAtumSetSeed() {

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
@@ -20,7 +20,7 @@ public class CreateWorldScreenMixin {
 
     @Inject(method = "buttonClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;method_2935(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE))
     public void onGenerate(CallbackInfo ci) {
-        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) || isAtumSetSeed();
+        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0") || isAtumSetSeed();
     }
 
     private boolean isAtumSetSeed() {
@@ -31,7 +31,7 @@ public class CreateWorldScreenMixin {
                 if (Modifier.isStatic(field.getModifiers())) {
                     if (field.getName().equals("seed")) {
                         String seed = (String) field.get(null);
-                        if (!StringUtils.isEmpty(seed)) isSetSeed = true;
+                        if (!StringUtils.isEmpty(seed) && !seed.trim().equals("0")) isSetSeed = true;
                         else break;
                     }
                     if (field.getName().equals("isRunning")) {

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -59,17 +59,20 @@ public abstract class ServerPlayerEntityMixin {
             }
 
             if (oldDimension instanceof TheNetherDimension && newDimension instanceof OverworldDimension) {
+                // doing this early, so we can use the portal pos list for the portal number
+                int portalIndex = InGameTimerUtils.isBlindTraveled(this.lastPortalPos);
+                boolean isNewPortal = InGameTimerUtils.isLoadableBlind(newDimension, lastPortalPos.method_613(0, 0, 0), Vec3d.method_604(player.x, player.y, player.z));;
                 if (this.isEnoughTravel(player)) {
-                    int portalIndex = InGameTimerUtils.isBlindTraveled(lastPortalPos);
-                    GameInstance.getInstance().callEvents("nether_travel", factory -> factory.getDataValue("portal").equals(String.valueOf(portalIndex)));
+                    int portalNum = InGameTimerUtils.getPortalNumber(this.lastPortalPos);
+                    GameInstance.getInstance().callEvents("nether_travel", factory -> factory.getDataValue("portal").equals(String.valueOf(portalNum)));
                     InGameTimer.getInstance().tryInsertNewTimeline("nether_travel");
                     if (portalIndex == 0) {
                         InGameTimer.getInstance().tryInsertNewTimeline("nether_travel_home");
                     } else {
                         timer.tryInsertNewTimeline("nether_travel_blind");
                     }
+                if (!timer.isCoop() && InGameTimer.getInstance().getCategory() == RunCategories.ANY) InGameTimerUtils.IS_CAN_WAIT_WORLD_LOAD = isNewPortal;
                 }
-                if (!timer.isCoop() && InGameTimer.getInstance().getCategory() == RunCategories.ANY) InGameTimerUtils.IS_CAN_WAIT_WORLD_LOAD = InGameTimerUtils.isLoadableBlind(newDimension, lastPortalPos.method_613(0, 0, 0), Vec3d.method_604(player.x, player.y, player.z));
             }
         }
     }

--- a/src/main/java/com/redlimerl/speedrunigt/timer/PracticeTimerManager.java
+++ b/src/main/java/com/redlimerl/speedrunigt/timer/PracticeTimerManager.java
@@ -6,7 +6,7 @@ import com.redlimerl.speedrunigt.timer.running.RunType;
 
 public class PracticeTimerManager {
 
-    public static final RunCategory PRACTICE_CATEGORY = RunCategoryBuilder.create("pratice_world", "", "Practice").setHideCategory(true).build();
+    public static final RunCategory PRACTICE_CATEGORY = RunCategoryBuilder.create("practice_world", "", "Practice").setHideCategory(true).build();
 
 
     public static void startPractice(float offsetTime) {

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -1,79 +1,23 @@
 [
     {
         "name": "obtain_iron_ingot",
-        "type": "advancement",
+        "type": "achievement",
         "data": {
-            "advancement": "story/smelt_iron"
-        }
-    },
-    {
-        "name": "obtain_iron_pickaxe",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/iron_tools"
-        }
-    },
-    {
-        "name": "obtain_lava_bucket",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/lava_bucket"
+            "achievement": "acquireIron"
         }
     },
     {
         "name": "enter_nether",
-        "type": "advancement",
+        "type": "insert_timeline",
         "data": {
-            "advancement": "story/enter_the_nether"
+            "timeline": "enter_nether"
         }
     },
     {
-        "name": "distract_piglin",
-        "type": "advancement",
+        "name": "killed_blaze",
+        "type": "timeline",
         "data": {
-            "advancement": "nether/distract_piglin"
-        }
-    },
-    {
-        "name": "enter_bastion",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/find_bastion"
-        }
-    },
-    {
-        "name": "loot_bastion",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/loot_bastion"
-        }
-    },
-    {
-        "name": "obtain_obsidian",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/form_obsidian"
-        }
-    },
-    {
-        "name": "obtain_crying_obsidian",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/obtain_crying_obsidian"
-        }
-    },
-    {
-        "name": "enter_fortress",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/find_fortress"
-        }
-    },
-    {
-        "name": "obtain_blaze_rod",
-        "type": "advancement",
-        "data": {
-            "advancement": "nether/obtain_blaze_rod"
+            "timeline": "killed_blaze"
         }
     },
     {
@@ -91,24 +35,17 @@
         }
     },
     {
-        "name": "enter_stronghold",
-        "type": "advancement",
-        "data": {
-            "advancement": "story/follow_ender_eye"
-        }
-    },
-    {
         "name": "enter_end",
-        "type": "advancement",
+        "type": "insert_timeline",
         "data": {
-            "advancement": "story/enter_the_end"
+            "timeline": "enter_end"
         }
     },
     {
         "name": "kill_dragon",
         "type": "insert_timeline",
         "data": {
-            "entity": "kill_ender_dragon"
+            "timeline": "kill_ender_dragon"
         }
     },
     {

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -15,7 +15,7 @@
     },
     {
         "name": "killed_blaze",
-        "type": "timeline",
+        "type": "insert_timeline",
         "data": {
             "timeline": "killed_blaze"
         }


### PR DESCRIPTION
fixes:
- i forgot to backport the achievements commit
- blind events didn't count up correctly
- ender dragon kill event and practice_world category had a typo
- multiplayer event triggers on world join b/c stats name is lowercase and can mismatch username
- seed "0" was considered set_seed
- set_seed detection didn't work with atum