### PR TITLE
1.8.3-15w14a - various fixes

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
@@ -4,6 +4,7 @@ import com.redlimerl.speedrunigt.timer.InGameTimerUtils;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,14 +14,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-@Mixin(CreateWorldScreen.class)
+@Mixin(value = CreateWorldScreen.class, priority = 1050)
 public class CreateWorldScreenMixin {
 
     @Shadow private TextFieldWidget seedField;
 
     @Inject(method = "buttonClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;startGame(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE))
     public void onGenerate(CallbackInfo ci) {
-        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0") || isAtumSetSeed();
+        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0");
+    }
+
+    @Dynamic
+    // method injected by atum
+    @Inject(method = "createLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;startIntegratedServer(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE), require = 0)
+    public void onGenerateAtum(CallbackInfo ci) {
+        InGameTimerUtils.IS_SET_SEED = isAtumSetSeed();
     }
 
     private boolean isAtumSetSeed() {

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/CreateWorldScreenMixin.java
@@ -20,7 +20,7 @@ public class CreateWorldScreenMixin {
 
     @Inject(method = "buttonClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;startGame(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/level/LevelInfo;)V", shift = At.Shift.BEFORE))
     public void onGenerate(CallbackInfo ci) {
-        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) || isAtumSetSeed();
+        InGameTimerUtils.IS_SET_SEED = !StringUtils.isEmpty(this.seedField.getText()) && !this.seedField.getText().trim().equals("0") || isAtumSetSeed();
     }
 
     private boolean isAtumSetSeed() {
@@ -31,7 +31,7 @@ public class CreateWorldScreenMixin {
                 if (Modifier.isStatic(field.getModifiers())) {
                     if (field.getName().equals("seed")) {
                         String seed = (String) field.get(null);
-                        if (!StringUtils.isEmpty(seed)) isSetSeed = true;
+                        if (!StringUtils.isEmpty(seed) && !seed.trim().equals("0")) isSetSeed = true;
                         else break;
                     }
                     if (field.getName().equals("isRunning")) {

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -60,17 +60,20 @@ public abstract class ServerPlayerEntityMixin {
             }
 
             if (oldDimension instanceof TheNetherDimension && newDimension instanceof OverworldDimension) {
+                // doing this early, so we can use the portal pos list for the portal number
+                int portalIndex = InGameTimerUtils.isBlindTraveled(this.lastPortalPos);
+                boolean isNewPortal = InGameTimerUtils.IS_CAN_WAIT_WORLD_LOAD = InGameTimerUtils.isLoadableBlind(newDimension, lastPortalPos.add(0, 0, 0), player.getPos().add(0, 0, 0));
                 if (this.isEnoughTravel(player)) {
-                    int portalIndex = InGameTimerUtils.isBlindTraveled(lastPortalPos);
-                    GameInstance.getInstance().callEvents("nether_travel", factory -> factory.getDataValue("portal").equals(String.valueOf(portalIndex)));
+                    int portalNum = InGameTimerUtils.getPortalNumber(this.lastPortalPos);
+                    GameInstance.getInstance().callEvents("nether_travel", factory -> factory.getDataValue("portal").equals(String.valueOf(portalNum)));
                     InGameTimer.getInstance().tryInsertNewTimeline("nether_travel");
                     if (portalIndex == 0) {
                         InGameTimer.getInstance().tryInsertNewTimeline("nether_travel_home");
                     } else {
                         timer.tryInsertNewTimeline("nether_travel_blind");
                     }
+                if (!timer.isCoop() && InGameTimer.getInstance().getCategory() == RunCategories.ANY) InGameTimerUtils.IS_CAN_WAIT_WORLD_LOAD = isNewPortal;
                 }
-                if (!timer.isCoop() && InGameTimer.getInstance().getCategory() == RunCategories.ANY) InGameTimerUtils.IS_CAN_WAIT_WORLD_LOAD = InGameTimerUtils.isLoadableBlind(newDimension, lastPortalPos.add(0, 0, 0), player.getPos().add(0, 0, 0));
             }
         }
     }

--- a/src/main/java/com/redlimerl/speedrunigt/timer/PracticeTimerManager.java
+++ b/src/main/java/com/redlimerl/speedrunigt/timer/PracticeTimerManager.java
@@ -6,7 +6,7 @@ import com.redlimerl.speedrunigt.timer.running.RunType;
 
 public class PracticeTimerManager {
 
-    public static final RunCategory PRACTICE_CATEGORY = RunCategoryBuilder.create("pratice_world", "", "Practice").setHideCategory(true).build();
+    public static final RunCategory PRACTICE_CATEGORY = RunCategoryBuilder.create("practice_world", "", "Practice").setHideCategory(true).build();
 
 
     public static void startPractice(float offsetTime) {

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -15,7 +15,7 @@
     },
     {
         "name": "killed_blaze",
-        "type": "timeline",
+        "type": "insert_timeline",
         "data": {
             "timeline": "killed_blaze"
         }


### PR DESCRIPTION
fixes:
- blind events didn't count up correctly
- blaze kill event and practice_world category had a typo
- seed "0" was considered set_seed
- set_seed detection didn't work with atum