### PR TITLE
register missing accessor

### DIFF
--- a/src/main/resources/speedrunigt.mixins.json
+++ b/src/main/resources/speedrunigt.mixins.json
@@ -27,6 +27,7 @@
     "PlayerAdvancementTrackerMixin",
     "ServerStatHandlerMixin",
     "access.AbstractButtonWidgetAccessor",
+    "access.DoubleOptionSliderWidgetAccessor",
     "access.FontManagerAccessor",
     "access.FontStorageAccessor",
     "access.MinecraftClientAccessor",


### PR DESCRIPTION
## Merge base version
- MC Version: 20w14infinite
- SpeedRunIGT Version: 14.1

## Changes
add missing DoubleOptionSliderWidgetAccessor to mixin file to fix mixin processor crash when changing settings
