### PR TITLE
Fix enabling cheats before timer start (1.19.2)

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
@@ -14,7 +14,12 @@ public class IntegratedServerMixin {
 
     @Inject(method = "openToLan", at = @At("RETURN"))
     public void onOpenLan(GameMode gameMode, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> cir) {
-        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) InGameTimer.getInstance().openedLanIntegratedServer();
+        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) {
+            InGameTimer.getInstance().openedLanIntegratedServer();
+            if(cheatsAllowed){
+                InGameTimer.getInstance().setCheatAvailable(true);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Merge base version
- MC Version: 1.19.2
- SpeedRunIGT Version: 14.1

## Changes
title
