### PR TITLE
Fix enabling cheats before timer start and misc updates (1.4.7)

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/ClientPlayerEntityMixin.java
@@ -163,9 +163,10 @@ public abstract class ClientPlayerEntityMixin extends PlayerEntity {
             }
         }
 
-        //For Timelines
-        if (this.y >= 100 && this.inBed)
-            timer.tryInsertNewTimeline("sleep_on_tower");
+        // This is flawed as the most recent towers do a strat called "bunk bed" where the player spawns well below y 100
+        // For Timelines
+        // if (this.y >= 100 && this.isSleeping())
+        //     timer.tryInsertNewTimeline("sleep_on_tower");
     }
 
 

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
@@ -14,7 +14,12 @@ public class IntegratedServerMixin {
 
     @Inject(method = "method_3000", at = @At("RETURN"))
     public void onOpenLan(GameMode bl, boolean par2, CallbackInfoReturnable<String> cir) {
-        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) InGameTimer.getInstance().openedLanIntegratedServer();
+        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) {
+            InGameTimer.getInstance().openedLanIntegratedServer();
+            if (par2) {
+                InGameTimer.getInstance().setCheatAvailable(true);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -83,6 +83,6 @@ public abstract class ServerPlayerEntityMixin {
                 .filter(Objects::nonNull) // Remove nulls
                 .map(ItemStack::getItem) // Turn each item stack into its item
                 .collect(Collectors.toSet()); // Collect to a set of items that the player has
-        return currentItemTypes.contains(Item.EYE_OF_ENDER) || (currentItemTypes.contains(Item.ENDER_PEARL) && (currentItemTypes.contains(Item.BLAZE_ROD) || currentItemTypes.contains(Item.BLAZE_POWDER)));
+        return currentItemTypes.contains(Item.EYE_OF_ENDER) || currentItemTypes.contains(Item.BLAZE_ROD) || currentItemTypes.contains(Item.BLAZE_POWDER);
     }
 }

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -20,6 +20,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -31,6 +32,13 @@ public abstract class ServerPlayerEntityMixin {
 
     private ServerWorld beforeWorld = null;
     private Vec3d lastPortalPos = null;
+
+    @Inject(method = "respawnPlayer", at = @At("RETURN"))
+    private void onRespawnPlayer(ServerPlayerEntity dimension, int alive, boolean par3, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+        if (cir.getReturnValue().y > 150 && cir.getReturnValue().method_3186() /*gets respawn point, null if using world spawn*/ != null) {
+            InGameTimer.getInstance().tryInsertNewTimeline("tower_start");
+        }
+    }
 
     @Inject(method = "teleportToDimension", at = @At("HEAD"))
     public void onChangeDimension(ServerPlayerEntity player, int dimension, CallbackInfo ci) {

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -35,6 +35,13 @@
         }
     },
     {
+        "name": "tower_start",
+        "type": "insert_timeline",
+        "data": {
+            "timeline": "tower_start"
+        }
+    },
+    {
         "name": "enter_end",
         "type": "insert_timeline",
         "data": {


### PR DESCRIPTION
## Merge base version
- MC Version: 1.4.7
- SpeedRunIGT Version: 14.1

## Changes
- Fix enabling cheats before timer start
- Only require rods for nether travel
- Remove `sleep_on_tower`
- Add `start_tower` timeline and event