### PR TITLE
Fix enabling cheats before timer start and update nether travel (1.13.2)

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
@@ -14,7 +14,12 @@ public class IntegratedServerMixin {
 
     @Inject(method = "method_20311", at = @At("RETURN"))
     public void onOpenLan(GameMode gameMode, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> cir) {
-        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) InGameTimer.getInstance().openedLanIntegratedServer();
+        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) {
+            InGameTimer.getInstance().openedLanIntegratedServer();
+            if(cheatsAllowed){
+                InGameTimer.getInstance().setCheatAvailable(true);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -73,6 +73,6 @@ public abstract class ServerPlayerEntityMixin {
                 .filter(Objects::nonNull) // Remove nulls
                 .map(ItemStack::getItem) // Turn each item stack into its item
                 .collect(Collectors.toSet()); // Collect to a set of items that the player has
-        return currentItemTypes.contains(Items.EYE_OF_ENDER) || (currentItemTypes.contains(Items.ENDER_PEARL) && (currentItemTypes.contains(Items.BLAZE_ROD) || currentItemTypes.contains(Items.BLAZE_POWDER)));
+        return currentItemTypes.contains(Items.EYE_OF_ENDER) || currentItemTypes.contains(Items.BLAZE_ROD) || currentItemTypes.contains(Items.BLAZE_POWDER);
     }
 }


### PR DESCRIPTION
## Merge base version
- MC Version: 1.13.2
- SpeedRunIGT Version: 14.1

## Changes
- Fix enabling cheats before timer start
- Only require rods for nether travel