### PR TITLE
Fix enabling cheats before timer start and misc updates (1.14.4)

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/server/IntegratedServerMixin.java
@@ -14,7 +14,12 @@ public class IntegratedServerMixin {
 
     @Inject(method = "openToLan", at = @At("RETURN"))
     public void onOpenLan(GameMode gameMode, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> cir) {
-        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) InGameTimer.getInstance().openedLanIntegratedServer();
+        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE) {
+            InGameTimer.getInstance().openedLanIntegratedServer();
+            if(cheatsAllowed){
+                InGameTimer.getInstance().setCheatAvailable(true);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/timeline/ServerPlayerEntityMixin.java
@@ -85,6 +85,6 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
                 .filter(Objects::nonNull) // Remove nulls
                 .map(ItemStack::getItem) // Turn each item stack into its item
                 .collect(Collectors.toSet()); // Collect to a set of items that the player has
-        return currentItemTypes.contains(Items.ENDER_EYE) || (currentItemTypes.contains(Items.ENDER_PEARL) && (currentItemTypes.contains(Items.BLAZE_ROD) || currentItemTypes.contains(Items.BLAZE_POWDER)));
+        return currentItemTypes.contains(Items.ENDER_EYE) || currentItemTypes.contains(Items.BLAZE_ROD) || currentItemTypes.contains(Items.BLAZE_POWDER);
     }
 }

--- a/src/main/resources/events/rsg.json
+++ b/src/main/resources/events/rsg.json
@@ -7,6 +7,13 @@
         }
     },
     {
+        "name": "obtain_gold_block",
+        "type": "insert_timeline",
+        "data": {
+            "timeline": "pick_gold_block"
+        }
+    },
+    {
         "name": "obtain_iron_pickaxe",
         "type": "advancement",
         "data": {


### PR DESCRIPTION
## Merge base version
- MC Version: 1.14.4
- SpeedRunIGT Version: 14.1

## Changes
- Fix enabling cheats before timer start
- Add obtain_gold_block event
- Only require rods for nether travel
