### PR TITLE
15.1: record file consistency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ yarn_mappings=1.16.1.build.19
 loader_version=0.14.25
 
 # Mod Properties
-mod_version=15.0
+mod_version=15.1
 maven_group=com.redlimerl.speedrunigt
 archives_base_name=SpeedRunIGT

--- a/src/main/java/com/redlimerl/speedrunigt/mixins/MinecraftClientMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/MinecraftClientMixin.java
@@ -70,7 +70,6 @@ public abstract class MinecraftClientMixin {
 
     @Shadow @Final public TextRenderer textRenderer;
     @Shadow @Final private Window window;
-    private boolean disconnectCheck = false;
 
     @Inject(at = @At("HEAD"), method = "createWorld")
     public void onCreate(String worldName, LevelInfo levelInfo, RegistryTracker.Modifiable registryTracker, GeneratorOptions generatorOptions, CallbackInfo ci) {
@@ -86,7 +85,6 @@ public abstract class MinecraftClientMixin {
         InGameTimer.getInstance().setCheatAvailable(levelInfo.areCommandsAllowed());
         InGameTimer.getInstance().checkDifficulty(levelInfo.getDifficulty());
         InGameTimerUtils.IS_CHANGING_DIMENSION = true;
-        this.disconnectCheck = false;
     }
 
     @Inject(at = @At("HEAD"), method = "startIntegratedServer(Ljava/lang/String;)V")
@@ -100,14 +98,10 @@ public abstract class MinecraftClientMixin {
             e.printStackTrace();
         }
         InGameTimerUtils.IS_CHANGING_DIMENSION = true;
-        this.disconnectCheck = false;
     }
 
     @Inject(method = "openScreen", at = @At("RETURN"))
     public void onSetScreen(Screen screen, CallbackInfo ci) {
-        if (screen instanceof LevelLoadingScreen) {
-            this.disconnectCheck = true;
-        }
         if (InGameTimerClientUtils.FAILED_CATEGORY_INIT_SCREEN != null) {
             Screen screen1 = InGameTimerClientUtils.FAILED_CATEGORY_INIT_SCREEN;
             InGameTimerClientUtils.FAILED_CATEGORY_INIT_SCREEN = null;
@@ -293,7 +287,7 @@ public abstract class MinecraftClientMixin {
     }
 
     // Record save
-    @Inject(method = "stop", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;close()V", shift = At.Shift.BEFORE))
+    @Inject(method = "stop", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;close()V"))
     public void onStop(CallbackInfo ci) {
         InGameTimer.getInstance().writeRecordFile(false);
     }
@@ -301,7 +295,10 @@ public abstract class MinecraftClientMixin {
     // Disconnecting fix
     @Inject(at = @At("HEAD"), method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;)V")
     public void disconnect(CallbackInfo ci) {
-        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE && this.disconnectCheck) {
+        // seedqueue suppresses disconnect calls for worlds in queue,
+        // and the client world is set after starting the server,
+        // which where the stray disconnect calls come from.
+        if (InGameTimer.getInstance().getStatus() != TimerStatus.NONE && this.world != null) {
             GameInstance.getInstance().callEvents("leave_world");
             InGameTimer.leave();
         }

--- a/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
+++ b/src/main/java/com/redlimerl/speedrunigt/timer/InGameTimer.java
@@ -689,7 +689,9 @@ public class InGameTimer implements Serializable {
                 //if ((toStatus == TimerStatus.IDLE || toStatus == TimerStatus.PAUSED) && !isCompleted()) TheRunRequestHelper.updateTimerData(this, TheRunTimer.PacketType.PAUSE);
                 if (this.isStarted()) {
                     if (SpeedRunOption.getOption(SpeedRunOptions.TIMER_DATA_AUTO_SAVE) == SpeedRunOptions.TimerSaveInterval.PAUSE && this.status != TimerStatus.LEAVE) save();
-                    this.writeRecordFile(true);
+                    // writes the global file on leaving the world.
+                    // otherwise with seedqueue, the global record is only updated upon joining the next world.
+                    this.writeRecordFile(toStatus != TimerStatus.LEAVE);
                 }
             }
         } else {


### PR DESCRIPTION
fixes disconnect inject not running, causing InGameTimer#leave to not be called and leave_world event to not fire. also, writes the global record file on "leave" pauses, as otherwise seedqueue users have to wait to join another world for the global record file to be written during InGameTimer#start. also, Shift#Before on an inject doesn't really make sense so I removed it, in testing it works but if there was any specific reason for that i can readd it easily.

fixes #209.