### PR TITLE
support legacy fabric api

### DIFF
--- a/src/main/java/com/redlimerl/speedrunigt/mixins/screen/ControlsOptionsScreenMixin.java
+++ b/src/main/java/com/redlimerl/speedrunigt/mixins/screen/ControlsOptionsScreenMixin.java
@@ -1,6 +1,6 @@
 package com.redlimerl.speedrunigt.mixins.screen;
 
-import net.minecraft.client.MinecraftClient;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.options.ControlsOptionsScreen;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,6 +11,6 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public abstract class ControlsOptionsScreenMixin extends Screen {
     @ModifyArg(method = "init", index = 2, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;<init>(IIILjava/lang/String;)V"))
     private int dynamicDoneButton(int num) {
-        return this.height / 6 + 24 * (((MinecraftClient.getInstance().options.allKeys.length + 2 - 1) / 2));
+        return !FabricLoader.getInstance().isModLoaded("legacy-fabric-api") ? this.height / 6 + 24 * ((this.client.options.allKeys.length + 2 - 1) / 2) : num;
     }
 }


### PR DESCRIPTION
## Merge base version
- MC Version: 1.6.4
- SpeedRunIGT Version: 14.2

## Changes
disable the ControlOptionsScreen done button height modification when legacy fabric api is loaded, as it makes that screen paginated

no need to make a release for this, just wanted close my issue
closes #171