### PR TITLE
Update to SpeedrunAPI 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "com.github.RedLime:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	// https://jitpack.io/#kingcontaria/speedrunapi
-	modImplementation "com.github.KingContaria:SpeedrunAPI:3d7827a9c1"
+	// https://jitpack.io/#contariaa/speedrunapi
+	modImplementation "com.github.contariaa:SpeedrunAPI:96811e85e8"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/src/main/java/com/redlimerl/speedrunigt/gui/screen/SpeedRunOptionScreenProvider.java
+++ b/src/main/java/com/redlimerl/speedrunigt/gui/screen/SpeedRunOptionScreenProvider.java
@@ -2,7 +2,7 @@ package com.redlimerl.speedrunigt.gui.screen;
 
 import net.minecraft.client.gui.screen.Screen;
 import org.jetbrains.annotations.NotNull;
-import org.mcsr.speedrunapi.config.api.SpeedrunConfigScreenProvider;
+import me.contaria.speedrunapi.config.api.SpeedrunConfigScreenProvider;
 
 @SuppressWarnings("unused")
 public class SpeedRunOptionScreenProvider implements SpeedrunConfigScreenProvider {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,7 +43,8 @@
   },
 
   "breaks": {
-    "ghostrunner": "<=3.0"
+    "ghostrunner": "<=3.0",
+    "speedrunapi": "<2.0"
   },
 
   "suggests": {


### PR DESCRIPTION
## Merge base version
- MC Version: 1.16.1
- SpeedRunIGT Version: 15.1, ig it would become 15.2 or smth, up to you

## Changes
Update to SpeedrunAPI 2.0, changing the package from `org.mcsr.speedrunapi` -> `me.contaria.speedrunapi` and adding `speedrunapi: "<2.0"` to the fabric.mod.json breaks clause
